### PR TITLE
Add nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1692447944,
+        "narHash": "sha256-fkJGNjEmTPvqBs215EQU4r9ivecV5Qge5cF/QDLVn3U=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d680ded26da5cf104dd2735a51e88d2d8f487b4d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,57 @@
+{
+  description = "A graphical satellite tracking software for linux";
+
+  inputs = {
+    nixpkgs.url = github:nixos/nixpkgs/nixos-unstable;
+    flake-utils.url = github:numtide/flake-utils;
+  };
+
+  outputs = {self, nixpkgs, flake-utils, ...}@inputs: flake-utils.lib.eachDefaultSystem (system:
+    let 
+      pkgs = import nixpkgs {
+        inherit system;
+      };
+      arftracksat = (with pkgs; stdenv.mkDerivation {
+          name = "arftracksat";
+          src = ./.;
+          nativeBuildInputs = [ 
+            cmake
+            mesa
+            curl
+            curlpp
+            nlohmann_json
+            freeglut
+            libGL
+            mesa_glu
+            glm
+            tree
+          ];
+          # Patch share location
+          postUnpack = ''
+            path=${placeholder "out"}
+            sed -i "s,/usr/local,$path," *-source/src/main.cpp
+            sed -i "s,/usr/local,$path," *-source/config.json
+          '';
+          buildPhase = "make -j $NIX_BUILD_CORES";
+          installPhase = ''
+            mkdir -p $out/bin $out/etc/arftracksat $out/share/arftracksat
+            mv arftracksat $out/bin
+            cd ..
+            mv config.json $out/etc/arftracksat/config.json
+            mv assets/earth.png assets/map.json $out/share/arftracksat
+          '';
+        }
+      );
+    in rec {
+      defaultApp = flake-utils.lib.mkApp {
+        drv = defaultPackage;
+      };
+      defaultPackage = arftracksat;
+      devShell = pkgs.mkShell {
+        buildInputs = [
+          arftracksat
+        ];
+      };
+    }
+  );
+}


### PR DESCRIPTION
I added a `flake.nix` file to easily install on NixOS.

The flake substitutes the nix store path for `/usr`, then it builds the program using CMake. 